### PR TITLE
Partially fix MultiPropertyAttributeDrawer in Unity 2022

### DIFF
--- a/Packages/com.varneon.vudon.editors/Editor/MultiPropertyAttributeDrawer.cs
+++ b/Packages/com.varneon.vudon.editors/Editor/MultiPropertyAttributeDrawer.cs
@@ -102,7 +102,7 @@ namespace Varneon.VUdon.Editors.Editor
                 {
                     GUI.color = nullError ? Color.red : Color.yellow;
 
-                    label = new GUIContent(label.text, multiAttribute.nullError ? errorIcon : warningIcon);
+                    label.image = multiAttribute.nullError ? errorIcon : warningIcon;
                 }
 
                 position = EditorGUI.PrefixLabel(position, label);
@@ -113,7 +113,7 @@ namespace Varneon.VUdon.Editors.Editor
 
                 EditorGUI.indentLevel = 0;
 
-                EditorGUI.PropertyField(position, property, GUIContent.none);
+                EditorGUI.ObjectField(position, property, GUIContent.none);
 
                 EditorGUI.indentLevel = indentLevel;
             }

--- a/Packages/com.varneon.vudon.editors/Editor/MultiPropertyAttributeDrawer.cs
+++ b/Packages/com.varneon.vudon.editors/Editor/MultiPropertyAttributeDrawer.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using UnityEditor;
+using UnityEditorInternal;
 using UnityEngine;
 
 namespace Varneon.VUdon.Editors.Editor
@@ -14,12 +15,23 @@ namespace Varneon.VUdon.Editors.Editor
             errorIcon = EditorGUIUtility.IconContent("console.erroricon").image,
             warningIcon = EditorGUIUtility.IconContent("console.warnicon").image;
 
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            float defaultHeight = EditorGUIUtility.singleLineHeight;
+            float spacing = EditorGUIUtility.standardVerticalSpacing;
+
+            return property.propertyType switch
+            {
+                SerializedPropertyType.Rect or SerializedPropertyType.RectInt => defaultHeight * 2 + spacing,
+                SerializedPropertyType.Bounds or SerializedPropertyType.BoundsInt => defaultHeight * 3 + spacing * 2,
+                _ => base.GetPropertyHeight(property, label),
+            };
+        }
+
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
             // Get the abstract multi attribute
             MultiPropertyAttribute multiAttribute = (MultiPropertyAttribute)attribute;
-
-            EditorGUI.BeginProperty(position, label, property);
 
             // Initialize the attribute if it hasn't been already
             if (!multiAttribute.initialized)
@@ -75,6 +87,8 @@ namespace Varneon.VUdon.Editors.Editor
                 EditorGUI.BeginDisabledGroup(!multiAttribute.disabledCheckFunction.Invoke());
             }
 
+            EditorGUI.BeginProperty(position, label, property);
+
             // Add alternative handling to ranged fields
             if (multiAttribute.isRange)
             {
@@ -88,7 +102,7 @@ namespace Varneon.VUdon.Editors.Editor
                 }
                 else
                 {
-                    EditorGUI.PropertyField(position, property, label);
+                    EditorGUI.PropertyField(position, property, label, true);
                 }
             }
             // Add alternative handling to fields with null warning
@@ -120,15 +134,96 @@ namespace Varneon.VUdon.Editors.Editor
             // Draw the default field
             else
             {
-                EditorGUI.PropertyField(position, property, label);
+                switch (property.propertyType)
+                {
+                    //case SerializedPropertyType.Generic:
+                    //    EditorGUI.LabelField(position, "MultiPropertyDrawer does not support Generic fields yet.");
+                    //    break;
+                    case SerializedPropertyType.Integer:
+                        property.intValue = EditorGUI.IntField(position, label, property.intValue);
+                        break;
+                    case SerializedPropertyType.Boolean:
+                        property.boolValue = EditorGUI.Toggle(position, label, property.boolValue);
+                        break;
+                    case SerializedPropertyType.Float:
+                        property.floatValue = EditorGUI.FloatField(position, label, property.floatValue);
+                        break;
+                    case SerializedPropertyType.String:
+                        property.stringValue = EditorGUI.TextField(position, label, property.stringValue);
+                        break;
+                    case SerializedPropertyType.Color:
+                        property.colorValue = EditorGUI.ColorField(position, label, property.colorValue);
+                        break;
+                    case SerializedPropertyType.ObjectReference:
+                        EditorGUI.ObjectField(position, property, label);
+                        break;
+                    case SerializedPropertyType.LayerMask:
+                        int mask = EditorGUI.MaskField(position, label, InternalEditorUtility.LayerMaskToConcatenatedLayersMask(property.intValue), InternalEditorUtility.layers); ;
+                        property.intValue = InternalEditorUtility.ConcatenatedLayersMaskToLayerMask(mask);
+                        break;
+                    case SerializedPropertyType.Enum:
+                        position = EditorGUI.PrefixLabel(position, label);
+                        int indentLevel = EditorGUI.indentLevel;
+                        EditorGUI.indentLevel = 0;
+                        property.enumValueIndex = EditorGUI.Popup(position, property.enumValueIndex, property.enumDisplayNames);
+                        EditorGUI.indentLevel = indentLevel;
+                        break;
+                    case SerializedPropertyType.Vector2:
+                        property.vector2Value = EditorGUI.Vector2Field(position, label, property.vector2Value);
+                        break;
+                    case SerializedPropertyType.Vector3:
+                        property.vector3Value = EditorGUI.Vector3Field(position, label, property.vector3Value);
+                        break;
+                    case SerializedPropertyType.Vector4:
+                        property.vector4Value = EditorGUI.Vector4Field(position, label, property.vector4Value);
+                        break;
+                    case SerializedPropertyType.Rect:
+                        property.rectValue = EditorGUI.RectField(position, label, property.rectValue);
+                        break;
+                    //case SerializedPropertyType.ArraySize:
+                    //    EditorGUI.LabelField(position, "MultiPropertyDrawer does not support Array fields yet.");
+                    //    break;
+                    //case SerializedPropertyType.Character:
+                    //    EditorGUI.LabelField(position, "MultiPropertyDrawer does not support Character fields yet.");
+                    //    break;
+                    case SerializedPropertyType.AnimationCurve:
+                        property.animationCurveValue = EditorGUI.CurveField(position, label, property.animationCurveValue);
+                        break;
+                    case SerializedPropertyType.Bounds:
+                        property.boundsValue = EditorGUI.BoundsField(position, label, property.boundsValue);
+                        break;
+                    case SerializedPropertyType.Gradient:
+                        property.gradientValue = EditorGUI.GradientField(position, label, property.gradientValue);
+                        break;
+                    case SerializedPropertyType.Quaternion:
+                        property.quaternionValue = Quaternion.Euler(EditorGUI.Vector3Field(position, label, property.quaternionValue.eulerAngles));
+                        break;
+                    case SerializedPropertyType.Vector2Int:
+                        property.vector2IntValue = EditorGUI.Vector2IntField(position, label, property.vector2IntValue);
+                        break;
+                    case SerializedPropertyType.Vector3Int:
+                        property.vector3IntValue = EditorGUI.Vector3IntField(position, label, property.vector3IntValue);
+                        break;
+                    case SerializedPropertyType.RectInt:
+                        property.rectIntValue = EditorGUI.RectIntField(position, label, property.rectIntValue);
+                        break;
+                    case SerializedPropertyType.BoundsInt:
+                        property.boundsIntValue = EditorGUI.BoundsIntField(position, label, property.boundsIntValue);
+                        break;
+                    default:
+                        // Draw the default property if the type hasn't already been implicitly implemented
+                        // However, this can result in recursive drawing
+                        EditorGUI.PropertyField(position, property, label, true);
+                        break;
+                }
             }
+
+            EditorGUI.EndProperty();
 
             if (multiAttribute.disable)
             {
                 EditorGUI.EndDisabledGroup();
             }
-
-            EditorGUI.EndProperty();
         }
     }
 }

--- a/Packages/com.varneon.vudon.editors/package.json
+++ b/Packages/com.varneon.vudon.editors/package.json
@@ -2,8 +2,8 @@
   "name": "com.varneon.vudon.editors",
   "displayName": "VUdon - Editors",
   "version": "0.1.0-alpha.8",
-  "unity": "2019.4",
-  "unityRelease": "29f1",
+  "unity": "2022.3",
+  "unityRelease": "6f1",
   "description": "Custom editors for VUdon prefab ecosystem",
   "author": {
     "name": "Varneon",


### PR DESCRIPTION
Minimum Unity version requirement is now 2022.3.6f1.

Unity 2022 seems to have introduced the possibility of recursive property drawers which breaks the implementation developed for Unity 2019.

Explicit handling has been implemented for all individual property types which prevents recursive field drawing, but it may have introduced other problems yet unknown.

For now this fixes majority of #10 in order to release a new version, but this issue must be revisited in the future to fix the remaining problems.

![image](https://github.com/user-attachments/assets/dd0df21a-4ac7-47ce-8557-c13e388ba1f3)